### PR TITLE
Add darwin support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ flint
 
 # Nix
 result*
+
+# direnv
+.direnv/

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
     nixpkgs,
     ...
   }: let
-    systems = ["x86_64-linux" "aarch64-linux"];
+    systems = ["x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin"];
     forEachSystem = nixpkgs.lib.genAttrs systems;
 
     pkgsForEach = nixpkgs.legacyPackages;


### PR DESCRIPTION
Adds darwin to supported system, builds fine on booth aarch64 and x86_64 darwin.

I also took the liberty to add the direnv state directory to gitignore.

