### PR TITLE
fix -fail-if-multiple-versions

### DIFF
--- a/main.go
+++ b/main.go
@@ -132,7 +132,11 @@ func main() {
 	printDependencies(flake.Deps, flake.ReverseDeps, options)
 
 	// Exit with an error if multiple versions were found and the flag is set
-	if options.FailIfMultipleVersions && len(flake.Deps) > 0 {
-		os.Exit(1)
+	if options.FailIfMultipleVersions {
+        for _, aliases := range flake.Deps {
+            if len(aliases) > 1 {
+                os.Exit(1)
+            }
+        }
 	}
 }


### PR DESCRIPTION
The alias count of each dependency must be checked to determine the exit code, not the total amount of dependencies.